### PR TITLE
Cleaning, applying naming rules

### DIFF
--- a/ArchiveUnpacker.sln.DotSettings
+++ b/ArchiveUnpacker.sln.DotSettings
@@ -1,2 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AIMS/@EntryIndexedValue">AIMS</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ApplyAutoDetectedRules/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=LocalFunctions/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unpacker/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/ArchiveUnpacker/Framework/FileType.cs
+++ b/ArchiveUnpacker/Framework/FileType.cs
@@ -1,7 +1,0 @@
-namespace ArchiveUnpacker.Framework
-{
-    public enum FileType
-    {
-        
-    }
-}

--- a/ArchiveUnpacker/Framework/UnpackerRegistry.cs
+++ b/ArchiveUnpacker/Framework/UnpackerRegistry.cs
@@ -6,25 +6,25 @@ namespace ArchiveUnpacker.Framework
 {
     internal static class UnpackerRegistry
     {
-        private static Dictionary<Type, Func<string, bool>> conditions = new Dictionary<Type, Func<string, bool>>();
+        private static readonly Dictionary<Type, Func<string, bool>> Conditions = new Dictionary<Type, Func<string, bool>>();
 
-        public static void Register<T>(Func<string, bool> condition) where T : IUnpacker
+        public static void Register<T>(Func<string, bool> condition) where T : IUnpacker, new()
         {
             var type = typeof(T);
-            if (conditions.ContainsKey(type))
+            if (Conditions.ContainsKey(type))
                 throw new Exception($"Condition for unpacker {type} has already been registered.");
 
-            conditions.Add(typeof(T), condition);
+            Conditions.Add(type, condition);
         }
 
         public static IUnpacker Get(string gameDir)
         {
-            var match = conditions.FirstOrDefault(x => x.Value(gameDir));
+            var match = Conditions.FirstOrDefault(x => x.Value(gameDir));
 
             if (match.Key is null)
                 return null;
 
-            return Activator.CreateInstance(match.Key) as IUnpacker;
+            return (IUnpacker)Activator.CreateInstance(match.Key);
         }
     }
 }


### PR DESCRIPTION
Overrides some default naming rules, cleans up some unused code, makes Register<T> require `new()`.