### PR TITLE
Update Artemis unpacker

### DIFF
--- a/ArchiveUnpacker/Unpackers/ArtemisUnpacker.cs
+++ b/ArchiveUnpacker/Unpackers/ArtemisUnpacker.cs
@@ -42,7 +42,7 @@ namespace ArchiveUnpacker.Unpackers
                 // read the individual entries
                 int entries = br.ReadInt32();
                 for (int i = 0; i < entries; i++) {
-                    string path = new string(br.ReadChars(br.ReadInt32()));
+                    string path = Encoding.UTF8.GetString(br.ReadBytes(br.ReadInt32()));
                     br.ReadBytes(4); // 4 unused bytes
                     uint offset = br.ReadUInt32();
                     uint size = br.ReadUInt32();


### PR DESCRIPTION
Added support for pf6 archives
Made it scan for archives in sub-directories as well
Squashed a bug where if the path contained Japanese characters it would read too much and break